### PR TITLE
Update utility.py

### DIFF
--- a/PizzaHat/cogs/utility.py
+++ b/PizzaHat/cogs/utility.py
@@ -29,7 +29,7 @@ class Utility(commands.Cog):
         if member is None:
             member = ctx.author
 
-        rolelist = [r.mention for r in member.roles if r != ctx.guild.default_role]
+        rolelist = [role.mention for role in list(user.roles[::-1]) if not role is ctx.guild.default_role]
         roles = ", ".join(rolelist)
 
         def format_date(dt:datetime.datetime):


### PR DESCRIPTION
Before the change, the roles were sorted backwards (if for example a member has the roles "Owner" and "Member" it would show "Member, Owner": the highest role at the bottom). Now, with the change, "Owner, Member" will be shown: the major role at the beginning.