### PR TITLE
Spelling mistake in antihoist.py

### DIFF
--- a/PizzaHat/cogs_hidden/antihoist.py
+++ b/PizzaHat/cogs_hidden/antihoist.py
@@ -31,7 +31,7 @@ class AntiHoist(Cog):
             try:
                 await member.edit(
                     nick = "Moderated Nickname",
-                    resaon = "PizzaHat anti-hoist"
+                    reason = "PizzaHat anti-hoist"
                 )
             except Exception:
                 pass


### PR DESCRIPTION
At line 34, "reason" was spelled incorrectly